### PR TITLE
セキュリティグループルールの命名改善

### DIFF
--- a/terraform/security_group.tf
+++ b/terraform/security_group.tf
@@ -7,32 +7,34 @@ resource "aws_security_group" "this" {
   }
 }
 
-resource "aws_security_group_rule" "ingress_https" {
+resource "aws_security_group_rule" "ingress_https_from_admin_ip" {
   type              = "ingress"
   from_port         = 443
   to_port           = 443
   protocol          = "tcp"
   security_group_id = aws_security_group.this.id
   cidr_blocks       = ["${var.ip_address}/32"]
-  description       = "Allow HTTPS from home IP"
+  description       = "Allow HTTPS from admin IP"
 }
 
-resource "aws_security_group_rule" "ingress_https_secondary" {
+resource "aws_security_group_rule" "ingress_https_from_secondary_vpc" {
   type              = "ingress"
   from_port         = 443
   to_port           = 443
   protocol          = "tcp"
   security_group_id = aws_security_group.this.id
   cidr_blocks       = [aws_vpc_ipv4_cidr_block_association.secondary.cidr_block]
+  description       = "Allow HTTPS from secondary VPC CIDR"
 }
 
-resource "aws_security_group_rule" "ingress_https_v2" {
+resource "aws_security_group_rule" "ingress_https_from_primary_vpc" {
   type              = "ingress"
   from_port         = 443
   to_port           = 443
   protocol          = "tcp"
   security_group_id = aws_security_group.this.id
   cidr_blocks       = [aws_vpc.primary.cidr_block]
+  description       = "Allow HTTPS from primary VPC CIDR"
 }
 
 # resource "aws_security_group_rule" "engress_https" {


### PR DESCRIPTION
## 概要
セキュリティグループルールの命名をより意味のあるものに改善しました。

## 変更内容
- `ingress_https` → `ingress_https_from_admin_ip` - 管理者IPからのHTTPSアクセス
- `ingress_https_secondary` → `ingress_https_from_secondary_vpc` - セカンダリVPC CIDRからのHTTPSアクセス  
- `ingress_https_v2` → `ingress_https_from_primary_vpc` - プライマリVPC CIDRからのHTTPSアクセス
- 各ルールにdescriptionを追加して目的を明確化

## テスト計画
- [ ] `terraform validate` でTerraform設定の検証
- [ ] `terraform plan` で変更内容の確認
- [ ] 既存のセキュリティグループルールが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)