### PR TITLE
セキュリティグループ名の改善

### DIFF
--- a/terraform/security_group.tf
+++ b/terraform/security_group.tf
@@ -1,9 +1,9 @@
 resource "aws_security_group" "this" {
   vpc_id = aws_vpc.primary.id
-  name   = "security_group_v1"
+  name   = "internal-https-sg"
 
   tags = {
-    Name = "security_group_v1"
+    Name = "internal-https-sg"
   }
 }
 


### PR DESCRIPTION
## Summary
- セキュリティグループ名を `security_group_v1` から `internal-https-sg` に変更
- VPC内部のHTTPS通信管理の目的が明確になるよう命名を改善

## 変更内容
- リソース名とタグ名を統一して変更
- 機能を明確に表現した命名規則に変更

## Test plan
- [ ] `terraform validate` でTerraform設定の検証
- [ ] `terraform plan` で変更内容の確認
- [ ] リソースの命名が一貫していることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)