### PR TITLE
terraform-aws-modulesを使用してセキュリティグループをモジュール化

### DIFF
--- a/terraform/security_group.tf
+++ b/terraform/security_group.tf
@@ -1,60 +1,48 @@
-resource "aws_security_group" "this" {
-  vpc_id = aws_vpc.primary.id
-  name   = "internal-https-sg"
+module "internal_https_sg" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "~> 5.0"
+
+  name        = "internal-https-sg"
+  description = "Security group for internal HTTPS access"
+  vpc_id      = aws_vpc.primary.id
+
+  ingress_with_cidr_blocks = [
+    {
+      from_port   = 443
+      to_port     = 443
+      protocol    = "tcp"
+      description = "Allow HTTPS from admin IP"
+      cidr_blocks = "${var.ip_address}/32"
+    },
+    {
+      from_port   = 443
+      to_port     = 443
+      protocol    = "tcp"
+      description = "Allow HTTPS from secondary VPC CIDR"
+      cidr_blocks = aws_vpc_ipv4_cidr_block_association.secondary.cidr_block
+    },
+    {
+      from_port   = 443
+      to_port     = 443
+      protocol    = "tcp"
+      description = "Allow HTTPS from primary VPC CIDR"
+      cidr_blocks = aws_vpc.primary.cidr_block
+    }
+  ]
+
+  egress_with_prefix_list_ids = [
+    {
+      from_port       = 443
+      to_port         = 443
+      protocol        = "tcp"
+      description     = "Allow HTTPS to S3 via VPC Gateway Endpoint"
+      prefix_list_ids = data.aws_prefix_list.s3.id
+    }
+  ]
 
   tags = {
     Name = "internal-https-sg"
   }
-}
-
-resource "aws_security_group_rule" "ingress_https_from_admin_ip" {
-  type              = "ingress"
-  from_port         = 443
-  to_port           = 443
-  protocol          = "tcp"
-  security_group_id = aws_security_group.this.id
-  cidr_blocks       = ["${var.ip_address}/32"]
-  description       = "Allow HTTPS from admin IP"
-}
-
-resource "aws_security_group_rule" "ingress_https_from_secondary_vpc" {
-  type              = "ingress"
-  from_port         = 443
-  to_port           = 443
-  protocol          = "tcp"
-  security_group_id = aws_security_group.this.id
-  cidr_blocks       = [aws_vpc_ipv4_cidr_block_association.secondary.cidr_block]
-  description       = "Allow HTTPS from secondary VPC CIDR"
-}
-
-resource "aws_security_group_rule" "ingress_https_from_primary_vpc" {
-  type              = "ingress"
-  from_port         = 443
-  to_port           = 443
-  protocol          = "tcp"
-  security_group_id = aws_security_group.this.id
-  cidr_blocks       = [aws_vpc.primary.cidr_block]
-  description       = "Allow HTTPS from primary VPC CIDR"
-}
-
-# resource "aws_security_group_rule" "engress_https" {
-#   type              = "egress"
-#   from_port         = 443
-#   to_port           = 443
-#   protocol          = "tcp"
-#   security_group_id = aws_security_group.this.id
-#   cidr_blocks       = [aws_vpc.primary.cidr_block]
-# }
-
-# S3 Gateway Endpoint Security Group Rule
-resource "aws_security_group_rule" "egress_https_s3" {
-  type              = "egress"
-  from_port         = 443
-  to_port           = 443
-  protocol          = "tcp"
-  security_group_id = aws_security_group.this.id
-  prefix_list_ids   = [data.aws_prefix_list.s3.id]
-  description       = "Allow HTTPS to S3 via VPC Gateway Endpoint"
 }
 
 # Data source for S3 prefix list


### PR DESCRIPTION
## Summary

- aws_security_groupリソースをterraform-aws-modules/security-group/awsモジュールに移行
- 複数のaws_security_group_ruleリソースを統合してより保守しやすい構造に変更
- 既存の機能（admin IP、VPC CIDR、S3エンドポイントアクセス）は全て維持

## Test plan

- [ ] terraform validate でTerraform設定の妥当性を確認
- [ ] terraform plan で適用前の変更内容を確認
- [ ] 必要に応じてterraform apply でテスト環境にて動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)