### PR TITLE
セキュリティグループをモジュール化

### DIFF
--- a/modules/security_group/main.tf
+++ b/modules/security_group/main.tf
@@ -1,0 +1,35 @@
+resource "aws_security_group" "this" {
+  name   = var.name
+  vpc_id = var.vpc_id
+
+  tags = merge(
+    {
+      Name = var.name
+    },
+    var.tags
+  )
+}
+
+resource "aws_security_group_rule" "ingress" {
+  count = length(var.ingress_rules)
+
+  type              = "ingress"
+  from_port         = var.ingress_rules[count.index].from_port
+  to_port           = var.ingress_rules[count.index].to_port
+  protocol          = var.ingress_rules[count.index].protocol
+  security_group_id = aws_security_group.this.id
+  cidr_blocks       = var.ingress_rules[count.index].cidr_blocks
+  description       = var.ingress_rules[count.index].description
+}
+
+resource "aws_security_group_rule" "egress" {
+  count = length(var.egress_rules)
+
+  type              = "egress"
+  from_port         = var.egress_rules[count.index].from_port
+  to_port           = var.egress_rules[count.index].to_port
+  protocol          = var.egress_rules[count.index].protocol
+  security_group_id = aws_security_group.this.id
+  cidr_blocks       = var.egress_rules[count.index].cidr_blocks
+  description       = var.egress_rules[count.index].description
+}

--- a/modules/security_group/outputs.tf
+++ b/modules/security_group/outputs.tf
@@ -1,0 +1,14 @@
+output "security_group_id" {
+  description = "セキュリティグループのID"
+  value       = aws_security_group.this.id
+}
+
+output "security_group_arn" {
+  description = "セキュリティグループのARN"
+  value       = aws_security_group.this.arn
+}
+
+output "security_group_name" {
+  description = "セキュリティグループの名前"
+  value       = aws_security_group.this.name
+}

--- a/modules/security_group/variables.tf
+++ b/modules/security_group/variables.tf
@@ -1,0 +1,39 @@
+variable "name" {
+  description = "セキュリティグループの名前"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC ID"
+  type        = string
+}
+
+variable "ingress_rules" {
+  description = "インバウンドルールのリスト"
+  type = list(object({
+    from_port   = number
+    to_port     = number
+    protocol    = string
+    cidr_blocks = list(string)
+    description = string
+  }))
+  default = []
+}
+
+variable "egress_rules" {
+  description = "アウトバウンドルールのリスト"
+  type = list(object({
+    from_port   = number
+    to_port     = number
+    protocol    = string
+    cidr_blocks = list(string)
+    description = string
+  }))
+  default = []
+}
+
+variable "tags" {
+  description = "タグ"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/security_group.tf
+++ b/terraform/security_group.tf
@@ -1,56 +1,44 @@
-resource "aws_security_group" "this" {
-  vpc_id = aws_vpc.primary.id
+module "security_group" {
+  source = "../modules/security_group"
+
   name   = "security_group_v1"
+  vpc_id = aws_vpc.primary.id
+
+  ingress_rules = [
+    {
+      from_port   = 443
+      to_port     = 443
+      protocol    = "tcp"
+      cidr_blocks = ["${var.ip_address}/32"]
+      description = "Allow HTTPS from home IP"
+    },
+    {
+      from_port   = 443
+      to_port     = 443
+      protocol    = "tcp"
+      cidr_blocks = [aws_vpc_ipv4_cidr_block_association.secondary.cidr_block]
+      description = "Allow HTTPS from secondary CIDR"
+    },
+    {
+      from_port   = 443
+      to_port     = 443
+      protocol    = "tcp"
+      cidr_blocks = [aws_vpc.primary.cidr_block]
+      description = "Allow HTTPS from VPC"
+    }
+  ]
+
+  egress_rules = [
+    {
+      from_port   = 443
+      to_port     = 443
+      protocol    = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+      description = "Allow HTTPS to VPC only"
+    }
+  ]
 
   tags = {
     Name = "security_group_v1"
   }
-}
-
-resource "aws_security_group_rule" "ingress_https" {
-  type              = "ingress"
-  from_port         = 443
-  to_port           = 443
-  protocol          = "tcp"
-  security_group_id = aws_security_group.this.id
-  cidr_blocks       = ["${var.ip_address}/32"]
-  description       = "Allow HTTPS from home IP"
-}
-
-resource "aws_security_group_rule" "ingress_https_secondary" {
-  type              = "ingress"
-  from_port         = 443
-  to_port           = 443
-  protocol          = "tcp"
-  security_group_id = aws_security_group.this.id
-  cidr_blocks       = [aws_vpc_ipv4_cidr_block_association.secondary.cidr_block]
-}
-
-resource "aws_security_group_rule" "ingress_https_v2" {
-  type              = "ingress"
-  from_port         = 443
-  to_port           = 443
-  protocol          = "tcp"
-  security_group_id = aws_security_group.this.id
-  cidr_blocks       = [aws_vpc.primary.cidr_block]
-}
-
-# resource "aws_security_group_rule" "engress_https" {
-#   type              = "egress"
-#   from_port         = 443
-#   to_port           = 443
-#   protocol          = "tcp"
-#   security_group_id = aws_security_group.this.id
-#   cidr_blocks       = [aws_vpc.primary.cidr_block]
-# }
-
-# S3 Gateway Endpoint Security Group Rule
-resource "aws_security_group_rule" "egress_https_vpc" {
-  type              = "egress"
-  from_port         = 443
-  to_port           = 443
-  protocol          = "tcp"
-  security_group_id = aws_security_group.this.id
-  cidr_blocks       = ["0.0.0.0/0"]
-  description       = "Allow HTTPS to VPC only"
 }


### PR DESCRIPTION
## 概要
- セキュリティグループとルールを再利用可能なモジュール化
- コードの保守性と可読性を向上

## 変更内容
- `modules/security_group/`ディレクトリを新規作成
- `main.tf` - セキュリティグループとルールのリソース定義
- `variables.tf` - 入力変数定義（name、vpc_id、ingress_rules、egress_rules、tags）
- `outputs.tf` - 出力値定義（security_group_id、security_group_arn、security_group_name）
- 既存の個別リソースをモジュール呼び出しに置き換え

## テストプラン
- [ ] `terraform validate`でTerraform構文の確認
- [ ] `terraform plan`でリソース変更計画の確認
- [ ] 既存のセキュリティグループの動作が維持されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)